### PR TITLE
Implemented GameState singleton

### DIFF
--- a/globals/game_state.gd
+++ b/globals/game_state.gd
@@ -1,0 +1,19 @@
+extends Node
+
+var current_scene: String : set = _set_current_scene, get = _get_current_scene
+
+# TODO: 
+# We don't need to keep track of all scenes, but what we can do is
+# keep track of all scenes for a particular level/year. So when we,
+# for example, have to restart, we can simply look at the first
+# scene in the array of scenes for our given year (which can also be stored here).
+var _game_scenes = [
+	"res://scenes/main/Test.tscn"
+]
+
+func _get_current_scene() -> String:
+	return current_scene
+
+func _set_current_scene(scene: String) -> void:
+	assert(scene in _game_scenes)
+	current_scene = scene

--- a/menus/title/title_menu.gd
+++ b/menus/title/title_menu.gd
@@ -5,7 +5,8 @@ class_name TITLE_MENU
 
 # Start the game at the scene specified in starting_scene
 func _on_play_pressed():
-	get_tree().change_scene_to_packed(starting_scene)
+	GameState.current_scene = starting_scene.resource_path
+	get_tree().change_scene_to_file(GameState.current_scene)
 
 # Quit out of the game
 func _on_quit_pressed():

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://menus/title/title_menu.tscn"
 config/features=PackedStringArray("4.2", "Forward Plus")
 run/max_fps=60
 
+[autoload]
+
+GameState="*res://globals/game_state.gd"
+
 [debug]
 
 settings/stdout/print_fps=true

--- a/scenes/main/Test.tscn
+++ b/scenes/main/Test.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=5 format=3 uid="uid://gyo7c48qalkt"]
 
-[ext_resource type="PackedScene" uid="uid://urlec0li4vsi" path="res://scenes/common/map_template_GWC124.tscn" id="1_0us5t"]
+[ext_resource type="PackedScene" uid="uid://dp065tuqfglwl" path="res://scenes/common/map_template_GWC124.tscn" id="1_0us5t"]
 [ext_resource type="Script" path="res://scenes/main/Test.gd" id="1_m3ssa"]
 [ext_resource type="PackedScene" uid="uid://bu0mw60kso2sl" path="res://entities/player/Player.tscn" id="2_hbgph"]
 [ext_resource type="PackedScene" uid="uid://dk2p23b6cvj8e" path="res://ui/ui.tscn" id="3_nvljr"]


### PR DESCRIPTION
The GameState singleton allows us to keep track of and modify various aspects of our games state as the game progresses. Currently it only keeps track of the current scene, but this can be extended to other parts of the game such as level, pickups, etc.,